### PR TITLE
fix luarocks install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,11 @@ endif()
 
 set(LSDBUS_SRCS src/lsdbus.c src/message.c src/introspect.c src/evl.c src/vtab.c)
 
+set(CONFIG_LUADIR "${CMAKE_INSTALL_PREFIX}/share/lua/${LUA_VER}" CACHE STRING "lua script dir")
+set(CONFIG_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib/lua/${LUA_VER}" CACHE STRING "lua lib dir")
+
 set(LSDBUS_INST_DIR
-  ${CMAKE_INSTALL_PREFIX}/lib/lua/${LUA_VER}/lsdbus/)
+  ${CONFIG_LIBDIR}/lsdbus/)
 
 add_library(core SHARED ${LSDBUS_SRCS})
 target_compile_options(core PRIVATE -Wall -Wextra)
@@ -57,7 +60,7 @@ install(FILES
   src/lsdbus/server.lua
   src/lsdbus/common.lua
   src/lsdbus/error.lua
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/share/lua/${LUA_VER}/lsdbus/
+  DESTINATION ${CONFIG_LUADIR}/lsdbus/
   )
 
 install(PROGRAMS

--- a/lsdbus-scm-0.rockspec
+++ b/lsdbus-scm-0.rockspec
@@ -22,6 +22,8 @@ dependencies = {
 build = {
    type = "cmake",
    variables = {
-      CMAKE_INSTALL_PREFIX = "$(PREFIX)"
-   }
+      CMAKE_INSTALL_PREFIX = "$(PREFIX)",
+      CONFIG_LUADIR = "$(LUADIR)",
+      CONFIG_LIBDIR = "$(LIBDIR)"
+   },
 }


### PR DESCRIPTION
pass the proper LIBDIR and LUADIR from luarocks, so that we get a sane path that works out of the box with 'luarocks path'.

before:

	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/lib/lua/5.4/lsdbus/core.so
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/share/lua/5.4/lsdbus/init.lua
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/share/lua/5.4/lsdbus/proxy.lua
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/share/lua/5.4/lsdbus/server.lua
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/share/lua/5.4/lsdbus/common.lua
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/share/lua/5.4/lsdbus/error.lua

after:

	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/lib/lsdbus/core.so
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/lua/lsdbus/init.lua
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/lua/lsdbus/proxy.lua
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/lua/lsdbus/server.lua
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/lua/lsdbus/common.lua
	-- Installing: /home/mischief/.luarocks/lib/luarocks/rocks-5.4/lsdbus/scm-0/lua/lsdbus/error.lua
	
note: i am not a cmake (or luarocks) expert, let me know if there's a better way to do this.