### PR TITLE
add credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ information which depending on the callback type may include
 (these are retrieved using `sd_bus_get_current_message(3)` and the
 respective `sd_bus_message_get_*(3)` functions).
 
+The method `b:credentials()` can be used within a callback to get the
+credentials of a caller. While the underlying API supports many fields within
+credentials, they are mostly unpopulated so only the `euid`, `pid`, and
+`unique_name` fields will be in the resulting table.
+
 #### Registering Interfaces: Properties, Methods and Signal
 
 Server object callbacks can be registered with
@@ -512,6 +517,7 @@ The `proxy:SetAV` uses the tovariant functions internally.
 | `bus:exit_loop()`                                                             | see `sd_event_exit(3)`                       |
 | `bus:get_fd()`                                                                | see `sd_event_get_fd(3)`                     |
 | `table = bus:context()`                                                       | see `sd_bus_message_set_destination(3)` etc. |
+| `table = bus:credentials()`                                                   | see `sd_bus_query_sender_creds(3)`           |
 | `number = bus:get_method_call_timeout`                                        | see `sd_bus_get_method_call_timeout(3)`      |
 | `bus:set_method_call_timeout`                                                 | see `sd_bus_set_method_call_timeout(3)`      |
 | `res = bus:testmsg(typestr, args...)`                                         | test Lua->D-Bus->Lua message roundtrip       |

--- a/src/lsdbus.c
+++ b/src/lsdbus.c
@@ -582,6 +582,8 @@ static const luaL_Reg lsdbus_bus_m [] = {
 	{ "emit_properties_changed", lsdbus_emit_prop_changed },
 	{ "emit_signal", lsdbus_emit_signal },
 	{ "context", lsdbus_context },
+	{ "credentials", lsdbus_credentials },
+	{ "negotiate_credentials", lsdbus_negotiate_credentials },
 	{ "loop", evl_loop },
 	{ "run", evl_run },
 	{ "get_fd", evl_get_fd },

--- a/src/lsdbus.h
+++ b/src/lsdbus.h
@@ -87,6 +87,8 @@ void vtable_cleanup(lua_State *L);
 int lsdbus_emit_prop_changed(lua_State *L);
 int lsdbus_emit_signal(lua_State *L);
 int lsdbus_context(lua_State *L);
+int lsdbus_credentials(lua_State *L);
+int lsdbus_negotiate_credentials(lua_State *L);
 struct lsdbus_slot* __lsdbus_slot_push(lua_State *L, sd_bus_slot *slot, uint32_t flags);
 int lsdbus_slot_push(lua_State *L, sd_bus_slot *slot, uint32_t flags);
 void init_reg_vtab_user(lua_State *L);

--- a/test/peer-testserver.lua
+++ b/test/peer-testserver.lua
@@ -104,6 +104,18 @@ local interface = {
 	 {direction="in", name="error", type="s"},
 	 handler=function(vt, err) error(err) end
       },
+
+      GetCredentials = {
+          { direction = "out", name = "euid", type = "i" },
+          { direction = "out", name = "pid", type = "i" },
+          handler = function(vt)
+              creds = vt._bus:credentials()
+              if not creds.euid or not creds.pid then
+                  error("missing credentials")
+              end
+              return creds.euid, creds.pid
+          end,
+      }
    },
    properties={
       Bar={

--- a/test/run.lua
+++ b/test/run.lua
@@ -18,6 +18,7 @@ TestToVariant = require("tovariant")
 TestSig = require("testsig")
 TestServer = require("testserver")
 TestEvSrc = require("testevsrc")
+TestCredentials = require("testcredentials")
 
 runner = lu.LuaUnit.new()
 

--- a/test/testcredentials.lua
+++ b/test/testcredentials.lua
@@ -1,0 +1,31 @@
+local lu = require("luaunit")
+local lsdb = require("lsdbus")
+local proxy = lsdb.proxy
+local have_unistd, unistd = pcall(require, "posix.unistd")
+
+local testconf = debug.getregistry()['lsdbus.testconfig']
+
+local TestCredentials = {}
+
+function TestCredentials:setup()
+	if not have_unistd then
+		lu.skip("no luaposix")
+	end
+
+	self.b = lsdb.open(testconf.bus)
+end
+
+function TestCredentials:teardown()
+	self.b = nil
+end
+
+function TestCredentials:TestCredentials()
+	local euid, pid = unistd.geteuid(), unistd.getpid()
+	local p = proxy.new(self.b, "lsdbus.test", "/1", "lsdbus.test.testintf0")
+	local reuid, rpid = p('GetCredentials')
+	lu.assert_equals(euid, reuid)
+	lu.assert_equals(pid, rpid)
+end
+
+return TestCredentials
+


### PR DESCRIPTION
this adds a bus metamethod, credentials, that gets the credentials from the current bus message being handled, similar to :context().

there are many accessors for credential data, but the only ones i found to work are pid, euid and unique name, so those are exposed for now.